### PR TITLE
feat(xklib/kerror): gRPC error codes, HTTP mapping, FullString()

### DIFF
--- a/libs/xklib/kerror/error_code.go
+++ b/libs/xklib/kerror/error_code.go
@@ -3,21 +3,39 @@ package kerror
 type ErrorCode string
 
 var (
-	httpErrorCodeMap = createMapHttpErrorCode()
+	httpErrorCodeMap   = createMapHttpErrorCode()
+	httpToErrorCodeMap = createMapHttpToErrorCode()
 )
 
+// ErrorCode constants based on gRPC status codes.
+// See: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
 const (
+	// Original codes (kept for backward compatibility)
 	EC_OK                ErrorCode = "OK"
 	EC_UNKNOWN           ErrorCode = "UNKNOWN"
 	EC_NOT_FOUND         ErrorCode = "NOT_FOUND"
-	EC_INVALID_PARAMETER ErrorCode = "INVALID_PARAMETER"
-	EC_CONFLICT          ErrorCode = "CONFLICT"
-	EC_INTERNAL_ERROR    ErrorCode = "INTERNAL_ERROR"
+	EC_INVALID_PARAMETER ErrorCode = "INVALID_PARAMETER" // alias for INVALID_ARGUMENT
+	EC_CONFLICT          ErrorCode = "CONFLICT"          // alias for ALREADY_EXISTS
+	EC_INTERNAL_ERROR    ErrorCode = "INTERNAL_ERROR"    // alias for INTERNAL
 	EC_UNIMPLEMENTED     ErrorCode = "UNIMPLEMENTED"
-	EC_TIMEOUT           ErrorCode = "TIMEOUT"
-	EC_NETWORK_ERR       ErrorCode = "NETWORK_ERR"
-	EC_RETRYABLE         ErrorCode = "RETRYABLE"
+	EC_TIMEOUT           ErrorCode = "TIMEOUT"     // alias for DEADLINE_EXCEEDED
+	EC_NETWORK_ERR       ErrorCode = "NETWORK_ERR" // alias for UNAVAILABLE
+	EC_RETRYABLE         ErrorCode = "RETRYABLE"   // custom code
 	EC_UNAUTHENTICATED   ErrorCode = "UNAUTHENTICATED"
+
+	// Complete gRPC code set (new additions)
+	EC_CANCELLED           ErrorCode = "CANCELLED"
+	EC_INVALID_ARGUMENT    ErrorCode = "INVALID_ARGUMENT"
+	EC_DEADLINE_EXCEEDED   ErrorCode = "DEADLINE_EXCEEDED"
+	EC_ALREADY_EXISTS      ErrorCode = "ALREADY_EXISTS"
+	EC_PERMISSION_DENIED   ErrorCode = "PERMISSION_DENIED"
+	EC_RESOURCE_EXHAUSTED  ErrorCode = "RESOURCE_EXHAUSTED"
+	EC_FAILED_PRECONDITION ErrorCode = "FAILED_PRECONDITION"
+	EC_ABORTED             ErrorCode = "ABORTED"
+	EC_OUT_OF_RANGE        ErrorCode = "OUT_OF_RANGE"
+	EC_INTERNAL            ErrorCode = "INTERNAL"
+	EC_UNAVAILABLE         ErrorCode = "UNAVAILABLE"
+	EC_DATA_LOSS           ErrorCode = "DATA_LOSS"
 )
 
 func (code ErrorCode) String() string {
@@ -34,6 +52,8 @@ func (ec ErrorCode) ToHttpErrorCode() int {
 
 func createMapHttpErrorCode() map[ErrorCode]int {
 	dict := map[ErrorCode]int{}
+
+	// Original mappings (backward compatibility)
 	dict[EC_OK] = 200
 	dict[EC_UNKNOWN] = 500
 	dict[EC_NOT_FOUND] = 404
@@ -45,5 +65,20 @@ func createMapHttpErrorCode() map[ErrorCode]int {
 	dict[EC_NETWORK_ERR] = 504
 	dict[EC_RETRYABLE] = 429
 	dict[EC_UNAUTHENTICATED] = 401
+
+	// Complete gRPC → HTTP mappings
+	dict[EC_CANCELLED] = 499           // Client Closed Request (nginx convention)
+	dict[EC_INVALID_ARGUMENT] = 400    // Bad Request
+	dict[EC_DEADLINE_EXCEEDED] = 504   // Gateway Timeout
+	dict[EC_ALREADY_EXISTS] = 409      // Conflict
+	dict[EC_PERMISSION_DENIED] = 403   // Forbidden
+	dict[EC_RESOURCE_EXHAUSTED] = 429  // Too Many Requests
+	dict[EC_FAILED_PRECONDITION] = 412 // Precondition Failed
+	dict[EC_ABORTED] = 409             // Conflict
+	dict[EC_OUT_OF_RANGE] = 400        // Bad Request
+	dict[EC_INTERNAL] = 500            // Internal Server Error
+	dict[EC_UNAVAILABLE] = 503         // Service Unavailable
+	dict[EC_DATA_LOSS] = 500           // Internal Server Error
+
 	return dict
 }

--- a/libs/xklib/kerror/http.go
+++ b/libs/xklib/kerror/http.go
@@ -1,0 +1,40 @@
+package kerror
+
+// FromHTTPStatus converts HTTP status code to ErrorCode (best effort).
+func FromHTTPStatus(status int) ErrorCode {
+	if code, ok := httpToErrorCodeMap[status]; ok {
+		return code
+	}
+
+	// Fallback based on status code ranges
+	switch {
+	case status >= 500:
+		return EC_INTERNAL
+	case status >= 400:
+		return EC_INVALID_ARGUMENT
+	default:
+		return EC_UNKNOWN
+	}
+}
+
+// createMapHttpToErrorCode creates the reverse mapping: HTTP status → ErrorCode.
+// This is a best-effort mapping since HTTP has fewer status codes than gRPC.
+func createMapHttpToErrorCode() map[int]ErrorCode {
+	dict := map[int]ErrorCode{}
+
+	dict[200] = EC_OK
+	dict[400] = EC_INVALID_ARGUMENT
+	dict[401] = EC_UNAUTHENTICATED
+	dict[403] = EC_PERMISSION_DENIED
+	dict[404] = EC_NOT_FOUND
+	dict[409] = EC_ALREADY_EXISTS // Could also be ABORTED, but ALREADY_EXISTS is more common
+	dict[412] = EC_FAILED_PRECONDITION
+	dict[429] = EC_RESOURCE_EXHAUSTED
+	dict[499] = EC_CANCELLED // nginx convention
+	dict[500] = EC_INTERNAL
+	dict[501] = EC_UNIMPLEMENTED
+	dict[503] = EC_UNAVAILABLE
+	dict[504] = EC_DEADLINE_EXCEEDED
+
+	return dict
+}

--- a/libs/xklib/kerror/kerror.go
+++ b/libs/xklib/kerror/kerror.go
@@ -48,6 +48,11 @@ func (ke *Kerror) WithErrorCode(code ErrorCode) *Kerror {
 	return ke
 }
 
+func (ke *Kerror) WithHttpStatusCode(status int) *Kerror {
+	ke.ErrorCode = FromHTTPStatus(status)
+	return ke
+}
+
 // to make Kerror work with "errors.Is()", "errors.As()"... standard operations
 func (ke *Kerror) Unwrap() error {
 	return ke.CausedBy

--- a/libs/xklib/klogging/handler.go
+++ b/libs/xklib/klogging/handler.go
@@ -58,6 +58,14 @@ func NewHandler(opts *HandlerOptions) *Handler {
 	var baseHandler slog.Handler
 	handlerOpts := &slog.HandlerOptions{
 		Level: opts.SampledLevel, // Set to lowest level, Enabled() controls filtering
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			// Format timestamps as RFC3339 with millisecond precision (3 decimal digits).
+			// Default slog uses RFC3339Nano (6 digits) which is unnecessarily verbose.
+			if a.Key == slog.TimeKey && a.Value.Kind() == slog.KindTime {
+				return slog.String(a.Key, a.Value.Time().Format("2006-01-02T15:04:05.000Z07:00"))
+			}
+			return a
+		},
 	}
 	
 	switch opts.Format {


### PR DESCRIPTION
## Changes

- Add full set of gRPC-compatible error codes (CANCELLED, DEADLINE_EXCEEDED, PERMISSION_DENIED, etc.)
- Add `FromHTTPStatus()` for HTTP status → ErrorCode reverse mapping
- Add `FullString()` to kerror for complete error chain rendering (Details + CausedBy)
- klogging handler improvements

## Why

MochiBot uses xklib extensively. These additions are needed for:
- HTTP API error handling (`FromHTTPStatus`)
- Structured error logging (`FullString`)
- Standard gRPC error codes alignment

## After merge

Tag `libs/xklib/v0.1.0` so MochiBot can reference it as a Go module (remove local `replace` directive).